### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: clojure
+
+before_install:
+    - yes | sudo lein upgrade
+
+before_script:
+    - lein cljsbuild once
+
+script:
+    - lein test :yes-i-know-the-tests-are-supposed-to-fail | diff test/fixtures/test_output -
+    - lein cljsbuild test 2>&1 | diff test/fixtures/test_output_cljs -
+

--- a/README.org
+++ b/README.org
@@ -1,3 +1,5 @@
+[[https://api.travis-ci.org/pjstadig/humane-test-output.png?branch=master]]
+
 #+STARTUP: hidestars showall
 * Humane test output for clojure.test
   This library does two things:


### PR DESCRIPTION
Hi. I finally forced myself to add the travis config.

Here's the build: https://travis-ci.org/nenadalm/humane-test-output/builds/122882836
- Leiningen was upgraded since version used by travis-ci has issues with test selectors
- cljsbuild is run before because downloading dependencies would be part of test output (so it wouldn't match with the file)
