### PR TITLE
fix actual diff output

### DIFF
--- a/src/pjstadig/util.cljc
+++ b/src/pjstadig/util.cljc
@@ -42,10 +42,19 @@
       (when message (println message))
       #?(:clj (binding [*out* (pp/get-pretty-writer *out*)]
                 (let [print-expected (fn [actual]
+                                       (let [only-in-a (clojure.string/replace actual #"Only in A: (.*)($|Only in B:.*)" "$1")
+                                             only-in-b (clojure.string/replace actual #"Only in A: (.*)($|Only in B:.*)" "$2")]
                                        (print "expected: ")
                                        (pp/pprint expected)
-                                       (print "  actual: ")
-                                       (pp/pprint actual))]
+                                       (println "  actual:")
+                                       (print "Only in A: ")
+                                       (pp/pprint (when (not (clojure.string/blank? only-in-a))
+                                                    (read-string only-in-a)))
+                                       (print "Only in B: ")
+                                       (pp/pprint (when (not (clojure.string/blank? only-in-b))
+                                                    (read-string only-in-b)))
+                                         )
+                                       )]
                   (if (seq diffs)
                     (doseq [[actual [a b]] diffs]
                       (print-expected actual)


### PR DESCRIPTION
Before:

```
Only in A: "#{{:id \"sighting-640bff75-c6c6-441d-85fe-3c863abc6c82\", :type \"sighting\", :timestamp #inst \"2016-02-04T12:00:00.000-00:00\", :source \"spam\", :confidence \"None\", :description \"sighting 3\", :owner \"foouser\"} {:id \"sighting-ccb7af53-d57a-492e-87e7-b32bca5aac82\", :type \"sighting\", :timestamp #inst \"2016-02-05T01:00:00.000-00:00\", :source \"foo\", :confidence \"High\", :description \"sighting 4\", :owner \"foouser\"} {:id \"sighting-ea2993cc-41db-4045-963f-255bd9e6c41d\", :type \"sighting\", :timestamp #inst \"2016-02-05T02:00:00.000-00:00\", :source \"bar\", :confidence \"Low\", :description \"sighting 5\", :owner \"foouser\"}}"
Only in B: ""
```

After this fix:

```
Only in A: #{{:id "sighting-87c06671-c9cb-4af3-8b4d-e4ca1e1c8bb1",
              :type "sighting",
              :timestamp #inst "2016-02-04T12:00:00.000-00:00",
              :source "spam",
              :confidence "None",
              :description "sighting 3",
              :owner "foouser"}
             {:id "sighting-47ef896a-884b-49ca-97ac-f3a363c44200",
              :type "sighting",
              :timestamp #inst "2016-02-05T02:00:00.000-00:00",
              :source "bar",
              :confidence "Low",
              :description "sighting 5",
              :owner "foouser"}
             {:id "sighting-3b584395-7650-451b-9d3d-7a822a0851a1",
              :type "sighting",
              :timestamp #inst "2016-02-05T01:00:00.000-00:00",
              :source "foo",
              :confidence "High",
              :description "sighting 4",
              :owner "foouser"}}
Only in B: nil
```
