### PR TITLE
Don't throw when calling = with a single value

### DIFF
--- a/src/pjstadig/assert_expr.cljc
+++ b/src/pjstadig/assert_expr.cljc
@@ -4,20 +4,19 @@
 
 (defn =-body
   [msg a more]
-  `(let [a# ~a]
-     (if-let [more# (seq (list ~@more))]
-       (let [result# (apply = a# more#)]
-         (if result#
-           (m/do-report {:type :pass, :message ~msg,
-                         :expected a#, :actual more#})
-           (m/do-report {:type :fail, :message ~msg,
-                         :expected a#, :actual more#,
-                         :diffs (map vector
-                                     more#
-                                     (map #(take 2 (m/diff a# %))
-                                          more#))}))
-         result#)
-       (throw (Exception. "= expects more than one argument")))))
+  `(let [a# ~a
+         more# (seq (list ~@more))
+         result# (apply = a# more#)]
+     (if result#
+       (m/do-report {:type :pass, :message ~msg,
+                     :expected a#, :actual more#})
+       (m/do-report {:type :fail, :message ~msg,
+                     :expected a#, :actual more#,
+                     :diffs (map vector
+                                 more#
+                                 (map #(take 2 (m/diff a# %))
+                                      more#))}))
+     result#))
 
 #?(:clj (defmethod assert-expr '= [menv msg [_ a & more]]
           (=-body msg a more)))

--- a/src/pjstadig/humane_test_output.clj
+++ b/src/pjstadig/humane_test_output.clj
@@ -6,20 +6,19 @@
 
 (defn =-body
   [msg a more]
-  `(let [a# ~a]
-     (if-let [more# (seq (list ~@more))]
-       (let [result# (apply = a# more#)]
-         (if result#
-           (do-report {:type :pass, :message ~msg,
-                       :expected a#, :actual more#})
-           (do-report {:type :fail, :message ~msg,
-                       :expected a#, :actual more#,
-                       :diffs (map vector
-                                   more#
-                                   (map #(take 2 (data/diff a# %))
-                                        more#))}))
-         result#)
-       (throw (Exception. "= expects more than one argument")))))
+  `(let [a# ~a
+         more# (seq (list ~@more))
+         result# (apply = a# more#)]
+     (if result#
+       (do-report {:type :pass, :message ~msg,
+                   :expected a#, :actual more#})
+       (do-report {:type :fail, :message ~msg,
+                   :expected a#, :actual more#,
+                   :diffs (map vector
+                               more#
+                               (map #(take 2 (data/diff a# %))
+                                    more#))}))
+     result#))
 
 (defonce activation-body
   (delay


### PR DESCRIPTION
Previously, having `activate!`d would cause tests in a consuming project to fail if they contained trivially true `=` calls, i.e., calls to `=` with a single argument.

It would throw an Exception with the message "= expects more than one argument", which isn't quite true. Sure, asserting `(= x)` doesn't make much sense, but it's valid Clojure, and will always return `true`. It might be a reasonable thing to lint for in `eastwood` or similar, or print some sort of warning about from this library, but throwing an exception seems excessive.

This PR removes that assertion/exception.