### PR TITLE
workaround CLJ-1966

### DIFF
--- a/src/pjstadig/assert_expr.cljc
+++ b/src/pjstadig/assert_expr.cljc
@@ -4,7 +4,7 @@
 
 (defn =-body
   [msg a more]
-  `(let [a# ~a]
+  `(let [a# (do ~a)]
      (if-let [more# (seq (list ~@more))]
        (let [result# (apply = a# more#)]
          (if result#

--- a/src/pjstadig/humane_test_output.clj
+++ b/src/pjstadig/humane_test_output.clj
@@ -7,7 +7,7 @@
 (defn =-body
   [msg a more]
   (if (seq more)
-    `(let [a# ~a
+    `(let [a# (do ~a)
            more# (seq (list ~@more))
            result# (apply = a# more#)]
        (if result#

--- a/test/pjstadig/humane_test_output/formatting_test.cljc
+++ b/test/pjstadig/humane_test_output/formatting_test.cljc
@@ -5,7 +5,13 @@
                             [pjstadig.fixtures.macro :refer [deftest+]])))
 
 (deftest t-nothing-to-see-here
-  (is true "everything should be A-OK"))
+  (is true "everything should be A-OK")
+  (is (= :clojure.spec.alpha/invalid
+         :clojure.spec.alpha/invalid)
+      "everything should be A-OK")
+  (is (= :clojure.spec/invalid
+         :clojure.spec/invalid)
+      "everything should be A-OK"))
 
 (deftest ^:intentionally-failing t-formatting
   (testing "THESE TESTS ARE INTENDED TO FAIL"


### PR DESCRIPTION
`(let [a :clojure.spec.alpha/invalid] ...)` is a spec error.

Since we rewrite
  `(is (= :clojure.spec.alpha/invalid foo))`
to
  `(let [a :clojure.spec.alpha/invalid] ...)`
we trigger this error. The workaround is to emit
  `(let [a (do :clojure.spec.alpha/invalid)] ...)`
instead.