### PR TITLE
Make report- a public fn

### DIFF
--- a/src/pjstadig/util.cljc
+++ b/src/pjstadig/util.cljc
@@ -31,7 +31,7 @@
           (pp/pprint-newline :linear)
           (recur (next aseq)))))))
 
-(defn- report-
+(defn report-
     [{:keys [type expected actual diffs message] :as event}]
       #?(:clj  (inc-report-counter :fail)
          :cljs (inc-report-counter! :fail))


### PR DESCRIPTION
I want to wrap `report-` before overriding the `report :fail` method. To do that the `report-` has to be public.