### PR TITLE
If either the expected or actual is nil. Don't display the diff

### DIFF
--- a/src/pjstadig/util.cljc
+++ b/src/pjstadig/util.cljc
@@ -52,15 +52,17 @@
                             (if (seq diffs)
                               (doseq [[actual [a b]] diffs]
                                 (print-expected actual)
-                                (p/rprint "    diff:")
-                                (if a
-                                  (do (p/rprint " - ")
-                                      (pp/pprint a *out*)
-                                      (p/rprint "          + "))
-                                  (p/rprint " + "))
-                                (when b
-                                  (pp/pprint b *out*))
-                                (p/clear))
+                                (when (and (some? expected) (some? actual))
+                                  (do
+                                    (p/rprint "    diff:")
+                                    (if a
+                                      (do (p/rprint " - ")
+                                          (pp/pprint a *out*)
+                                          (p/rprint "          + "))
+                                      (p/rprint " + "))
+                                    (when b
+                                      (pp/pprint b *out*))
+                                    (p/clear))))
                               (print-expected actual))))))
 
 (defn define-fail-report []

--- a/test/pjstadig/humane_test_output/formatting_test.cljc
+++ b/test/pjstadig/humane_test_output/formatting_test.cljc
@@ -28,7 +28,9 @@
            {:fo :bar :baz :quux}))
     (let [foo {:foo :bar :baz :quux :something "a long string?"
                :another-key "and another value"}]
-      (is (list? foo)))))
+      (is (list? foo)))
+    (is (= {:foo :bar}
+           nil))))
 
 (deftest+ ^:intentionally-failing t-macro-wrapping 1 2)
 


### PR DESCRIPTION
#25 
Figured it would be an easy change and I would like it in my own projects.
Example from tests
```FAIL in (t-formatting) (formatting_test.cljc:32)
THESE TESTS ARE INTENDED TO FAIL
expected: {:foo :bar}
  actual: nil
```